### PR TITLE
Add missing includes.

### DIFF
--- a/libbattery.c
+++ b/libbattery.c
@@ -16,7 +16,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <dirent.h>
+#include <unistd.h>
 
 #include "battery.h"
 


### PR DESCRIPTION
Does not compile on Fedora 41 without this.